### PR TITLE
Update kube_version to 1.27.7, argocd 2.9.3, kubespray 2.23.1

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -63,7 +63,8 @@ vm_k8s_worker = {
 
 # Kubernetes settings
 ########################################################################
-kube_version               = "v1.24.6"
+kubespray_image            = "quay.io/kubespray/kubespray:v2.23.1"
+kube_version               = "v1.27.7"
 kube_network_plugin        = "calico"
 enable_nodelocaldns        = false
 podsecuritypolicy_enabled  = false
@@ -71,4 +72,4 @@ persistent_volumes_enabled = false
 helm_enabled               = false
 ingress_nginx_enabled      = false
 argocd_enabled             = false
-argocd_version             = "v2.4.12"
+argocd_version             = "v2.9.3"

--- a/variables.tf
+++ b/variables.tf
@@ -191,13 +191,13 @@ variable "create_kubespray_host" {
 variable "kubespray_image" {
   type        = string
   description = "The Docker image to deploy Kubespray"
-  default     = "khanhphhub/kubespray:v2.22.0"
+  default     = "quay.io/kubespray/kubespray:v2.23.1"
 }
 
 variable "kube_version" {
   type        = string
   description = "Kubernetes version"
-  default     = "v1.24.6"
+  default     = "v1.27.7"
 }
 variable "kube_network_plugin" {
   type        = string
@@ -238,7 +238,7 @@ variable "argocd_enabled" {
 variable "argocd_version" {
   type        = string
   description = "The ArgoCD version to be installed"
-  default     = "v2.4.12"
+  default     = "v2.9.3"
 }
 
 


### PR DESCRIPTION
## Problem
Kubernetes versions >1.26.0 require a newer version of Kubespray (current implementation: v2.22.0).

## Solution
- Change current `kubespray_image` variable from docker image "khanhphhub/kubespray:v2.22.0" to "quay.io/kubespray/kubespray:v2.23.1".
- Change `kube_version` to `1.27.7`.
- Change `argocd` version to `2.9.3`.
- Update variables.tf according to above changes.

My kindest regards to @khanh-ph for putting this project together and for the accompanying blog post: https://www.khanhph.com/install-proxmox-kubernetes/


