### PR TITLE
Add MTU Configuration as a Variable for Proxmox Kubernetes SDN Integration

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -25,6 +25,8 @@ pm_timeout          = 600
 ########################################################################
 # Kubernetes internal network
 internal_net_name = "vmbr1"
+# Internal network MTU (you only need to change this when mtu is different from the default host settings)
+#internal_net_mtu = 1500
 # Internal network CIDR
 internal_net_subnet_cidr = "10.0.1.0/24"
 # Base64 encoded keys for Kubernetes admin authentication

--- a/modules/proxmox_ubuntu_vm/main.tf
+++ b/modules/proxmox_ubuntu_vm/main.tf
@@ -64,6 +64,7 @@ resource "proxmox_vm_qemu" "ubuntu_vm" {
   network {
     model  = "virtio"
     bridge = var.vm_net_name
+    mtu = var.vm_net_mtu
   }
 
   ipconfig0 = "ip=${cidrhost(var.vm_net_subnet_cidr, var.vm_host_number + count.index)}${local.vm_net_subnet_mask},gw=${local.vm_net_default_gw}"

--- a/modules/proxmox_ubuntu_vm/variables.tf
+++ b/modules/proxmox_ubuntu_vm/variables.tf
@@ -26,7 +26,8 @@ variable "vm_net_name" {
 
 variable "vm_net_mtu" {
   type        = string
-  description = "The MTU to use on the interface"  
+  description = "The MTU to use on the interface"
+  default     = null
 }
 
 variable "vm_net_subnet_cidr" {

--- a/modules/proxmox_ubuntu_vm/variables.tf
+++ b/modules/proxmox_ubuntu_vm/variables.tf
@@ -24,6 +24,11 @@ variable "vm_net_name" {
   description = ""
 }
 
+variable "vm_net_mtu" {
+  type        = string
+  description = "The MTU to use on the interface"  
+}
+
 variable "vm_net_subnet_cidr" {
   type        = string
   description = "Address prefix for the internal network"

--- a/variables.tf
+++ b/variables.tf
@@ -79,16 +79,16 @@ variable "internal_net_name" {
   default     = "vmbr1"
 }
 
+variable "internal_net_mtu" {
+  type        = string
+  description = "The mtu to use for the internal network"
+  default     = null
+}
+
 variable "internal_net_subnet_cidr" {
   type        = string
   description = "CIDR of the internal network"
   default     = "10.0.1.0/24"
-}
-
-variable "internal_net_mtu" {
-  type        = string
-  description = "The mtu to use for the internal network"
-  default     = 1500
 }
 
 variable "ssh_private_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "internal_net_subnet_cidr" {
   default     = "10.0.1.0/24"
 }
 
+variable "internal_net_mtu" {
+  type        = string
+  description = "The mtu to use for the internal network"
+  default     = 1500
+}
+
 variable "ssh_private_key" {
   type        = string
   description = "SSH private key in base64, will be used by Terraform client to connect to the Kubespray VM after provisioning. We can set its sensitivity to false; otherwise, the output of the Kubespray script will be hidden."

--- a/vm-k8s-nodes.tf
+++ b/vm-k8s-nodes.tf
@@ -1,6 +1,7 @@
 module "k8s_control_plane_nodes" {
   source = "./modules/proxmox_ubuntu_vm"
-
+  
+  vm_net_mtu                   = var.internal_net_mtu
   node_count                   = var.vm_k8s_control_plane["node_count"]
   pm_host                      = var.pm_host
   vm_ubuntu_tmpl_name          = var.vm_ubuntu_tmpl_name
@@ -24,6 +25,7 @@ module "k8s_control_plane_nodes" {
 module "k8s_worker_nodes" {
   source = "./modules/proxmox_ubuntu_vm"
 
+  vm_net_mtu                   = var.internal_net_mtu
   node_count                    = var.vm_k8s_worker["node_count"]
   pm_host                       = var.pm_host
   vm_ubuntu_tmpl_name           = var.vm_ubuntu_tmpl_name

--- a/vm-k8s-nodes.tf
+++ b/vm-k8s-nodes.tf
@@ -1,7 +1,6 @@
 module "k8s_control_plane_nodes" {
   source = "./modules/proxmox_ubuntu_vm"
   
-  vm_net_mtu                   = var.internal_net_mtu
   node_count                   = var.vm_k8s_control_plane["node_count"]
   pm_host                      = var.pm_host
   vm_ubuntu_tmpl_name          = var.vm_ubuntu_tmpl_name
@@ -14,6 +13,7 @@ module "k8s_control_plane_nodes" {
   vm_os_disk_storage           = var.vm_os_disk_storage
   vm_os_disk_size_gb           = var.vm_k8s_control_plane["disk_size"]
   vm_net_name                  = var.internal_net_name
+  vm_net_mtu                   = var.internal_net_mtu
   vm_net_subnet_cidr           = var.internal_net_subnet_cidr
   vm_host_number               = 10
   vm_user                      = var.vm_user
@@ -25,7 +25,6 @@ module "k8s_control_plane_nodes" {
 module "k8s_worker_nodes" {
   source = "./modules/proxmox_ubuntu_vm"
 
-  vm_net_mtu                   = var.internal_net_mtu
   node_count                    = var.vm_k8s_worker["node_count"]
   pm_host                       = var.pm_host
   vm_ubuntu_tmpl_name           = var.vm_ubuntu_tmpl_name
@@ -38,6 +37,7 @@ module "k8s_worker_nodes" {
   vm_os_disk_storage            = var.vm_os_disk_storage
   vm_os_disk_size_gb            = var.vm_k8s_worker["disk_size"]
   vm_net_name                   = var.internal_net_name
+  vm_net_mtu                    = var.internal_net_mtu
   vm_net_subnet_cidr            = var.internal_net_subnet_cidr
   vm_host_number                = 20
   vm_user                       = var.vm_user

--- a/vm-kubespray-host.tf
+++ b/vm-kubespray-host.tf
@@ -53,6 +53,7 @@ locals {
 module "kubespray_host" {
   source = "./modules/proxmox_ubuntu_vm"
 
+  vm_net_mtu                   = var.internal_net_mtu
   node_count                   = var.create_kubespray_host ? 1 : 0
   pm_host                      = var.pm_host
   vm_ubuntu_tmpl_name          = var.vm_ubuntu_tmpl_name

--- a/vm-kubespray-host.tf
+++ b/vm-kubespray-host.tf
@@ -53,7 +53,6 @@ locals {
 module "kubespray_host" {
   source = "./modules/proxmox_ubuntu_vm"
 
-  vm_net_mtu                   = var.internal_net_mtu
   node_count                   = var.create_kubespray_host ? 1 : 0
   pm_host                      = var.pm_host
   vm_ubuntu_tmpl_name          = var.vm_ubuntu_tmpl_name
@@ -66,6 +65,7 @@ module "kubespray_host" {
   vm_os_disk_storage           = var.vm_os_disk_storage
   vm_os_disk_size_gb           = 10
   vm_net_name                  = var.internal_net_name
+  vm_net_mtu                   = var.internal_net_mtu
   vm_net_subnet_cidr           = var.internal_net_subnet_cidr
   vm_host_number               = 5
   vm_user                      = var.vm_user


### PR DESCRIPTION
### Overview

This Pull Request introduces a new feature to the Proxmox Kubernetes project, allowing users to configure the **MTU (Maximum Transmission Unit)** value dynamically. This enhancement is crucial for environments utilizing the **Software Defined Networking (SDN)** feature in Proxmox, as SDN setups often require customized MTU settings to ensure proper network performance and compatibility.

### Context and Motivation

Previously, users had to either manually modify the MTU setting on nodes or exclude it from automated configuration (e.g., via `ignores`). While functional, this approach was not aligned with the project's goal of providing an automated and seamless Kubernetes setup on Proxmox. By integrating MTU configuration directly into the project's variables, users can now handle this requirement more efficiently, reducing manual intervention and potential misconfigurations.

### Changes Introduced

1. **New Variable for MTU Configuration**  
   - Added a variable (`internatl_net_mtu`) to the configuration file to allow users to specify their desired MTU value.  
   - Default value ensures backward compatibility for setups not requiring specific MTU adjustments, if its not set terraform will default to `null` and therefor ignore the whole mtu setting in the module

2. **Automation of MTU Configuration**  
   - The `internal_net_mtu` setting is applied automatically during node provisioning and configuration, eliminating the need for manual MTU adjustments.
   - In the downstream module for the nodes the variable `vm_net_mtu` is used, which also defaults to `null`

3. **Documentation Updates**  
   - Updated the project documentation to include details about the new `internal_net_mtu` variable, its purpose, and how to use it effectively.

### Key Benefits

- **Enhanced Automation**: Simplifies deployment in SDN environments by automating MTU settings.
- **Flexibility**: Users can easily adapt their configurations to match network requirements.
- **Improved Usability**: Reduces reliance on manual interventions, making the setup process more streamlined.

### Implementation Details

- The `internal_net_mtu` variable is integrated into the relevant module
- The module also includes default values for future PRs that might want to touch mtu
- Validation is included to ensure the MTU value provided is within acceptable ranges.

### Testing

- Tested on a Proxmox cluster 8.2.7 with SDN enabled and varying MTU requirements.  
- Verified that:
  - Default behavior remains unchanged for non-SDN setups.
  - User-defined MTU values are correctly applied during configuration.

### Backward Compatibility

This change maintains full compatibility with existing setups. If the mtu is not specified, the project defaults to using standard MTU settings of the hypervisor/bridge.

### Related Issues

- Resolves potential issues with Proxmox SDN setups where default MTU settings might cause networking problems.

### Notes for Reviewers

Please review the changes for any edge cases in non-SDN environments and verify the documentation's clarity regarding the `mtu` variable usage.

---

### Related Links
- **Branch**: [`[add-variable-for-mtu](https://github.com/Mawiguk0/proxmox-kubernetes/tree/add-variable-for-mtu)`](https://github.com/Mawiguk0/proxmox-kubernetes/tree/add-variable-for-mtu)